### PR TITLE
fixed adverts show to not require upload

### DIFF
--- a/app/views/adverts/show.html.erb
+++ b/app/views/adverts/show.html.erb
@@ -2,7 +2,7 @@
     <div class="column is-three-fifths">
         <h1 class="title"><%= @advert.book.title %></h1>
         <h2 class="subtitle"><%= @advert.book.authors %></h2>
-        <% if @advert.cover%>
+        <% if @advert.cover == true %>
             <%= image_tag(@advert.cover, width: 200) %>
         <% else %>
             <%= image_tag(@advert.book.image_link, :class => "image") %>


### PR DESCRIPTION
Fixed the Adverts show view to no longer return an error when an image is not uploaded when creating a new advert.