### PR TITLE
reversed name and logout buttons in navbar

### DIFF
--- a/app/views/shared/_topnav.html.erb
+++ b/app/views/shared/_topnav.html.erb
@@ -51,9 +51,9 @@
           <div class="buttons">
               <a>
                   <% if user_signed_in? %>
+                    <div id="username" class="button is-dark"><%= current_user.firstname.capitalize %></div>
                     <div id="logout"><%= link_to 'Logout', destroy_user_session_path, method:
                     "delete",class:"button is-light"%></div>
-                    <div id="username" class="button is-dark"><%= current_user.firstname.capitalize %></div>
                   <% else %>
                     <p><%= link_to 'Sign Up', new_user_registration_path, class:"button is-primary"%>
                     <%= link_to 'Login', new_user_session_path, class:"button is-light"%>


### PR DESCRIPTION
I reversed buttons for user name and logout in navbar. Eventually name could link to account details (future extension), and so it seemed intuitive to make logout the last option on the nav bar. Please review and merge if ok. Thanks